### PR TITLE
Functionality for parameter space exploration

### DIFF
--- a/analysis/batchscript.sh
+++ b/analysis/batchscript.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+#SBATCH -A C3SE2024-1-22 -p vera
+#SBATCH -t 05:00:00
+#SBATCH -n 16
+
+module load virtualenv/20.23.1-GCCcore-13.3.0 PyTorch-bundle/2.1.2-foss-2023a-CUDA-12.1.1 h5py/3.9.0-foss-2023a
+module load scikit-learn/1.3.1-gfbf-2023a scikit-image/0.22.0-foss-2023a
+
+module list
+
+source training_venv/bin/activate
+
+echo "Starting the training process"
+
+cp -r ./* $TMPDIR/
+
+cd $TMPDIR
+
+input_file=$1
+
+eval `head -n $SLURM_ARRAY_TASK_ID $input_file | tail -1`
+echo "[`date`] Running learning rate = ${learning_rate} batch size=$batch_size filename=lr_${learning_rate}_bs_$batch_size"
+
+python3 train_2layer_model.py -c double_layer_config.toml -b $batch_size -l ${learning_rate} -n lr_${learning_rate}_bs_$batch_size
+
+cp logs/*.log $SLURM_SUBMIT_DIR/logs/
+cp *.pt $SLURM_SUBMIT_DIR/saved_models/
+cp -r runs/* $SLURM_SUBMIT_DIR/runs/
+
+echo "Finito"
+

--- a/analysis/batchscript.sh
+++ b/analysis/batchscript.sh
@@ -4,19 +4,22 @@
 #SBATCH -t 05:00:00
 #SBATCH -n 16
 
+echo "[`date`] Loading modules..."
 module load virtualenv/20.23.1-GCCcore-13.3.0 PyTorch-bundle/2.1.2-foss-2023a-CUDA-12.1.1 h5py/3.9.0-foss-2023a
 module load scikit-learn/1.3.1-gfbf-2023a scikit-image/0.22.0-foss-2023a
 
 module list
 
+echo "[`date`] Sourcing virtual env..."
 source training_venv/bin/activate
 
-echo "Starting the training process"
 
+echo "[`date`] Copying data..."
 cp -r ./* $TMPDIR/
 
 cd $TMPDIR
 
+echo "[`date`] Finished copying data..."
 input_file=$1
 
 eval `head -n $SLURM_ARRAY_TASK_ID $input_file | tail -1`

--- a/analysis/example_config.toml
+++ b/analysis/example_config.toml
@@ -1,4 +1,7 @@
 datafile = "example_filelist.txt"
+learning_rate= 6.0e-6
+exponential_lr = true
+gamma = 0.99
 
 [network_settings]
 in_channels = 1

--- a/analysis/jobscript.sh
+++ b/analysis/jobscript.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+#SBATCH -A C3SE2024-1-22 -p vera
+#SBATCH -t 05:00:00
+#SBATCH -n 16
+
+module load virtualenv/20.23.1-GCCcore-13.3.0 PyTorch-bundle/2.1.2-foss-2023a-CUDA-12.1.1 h5py/3.9.0-foss-2023a
+module load scikit-learn/1.3.1-gfbf-2023a scikit-image/0.22.0-foss-2023a
+
+module list
+
+source training_venv/bin/activate
+
+echo "Starting the training process"
+
+cp -r ./* $TMPDIR/
+
+cd $TMPDIR
+
+python3 train_2layer_model.py -c double_layer_config.toml
+
+cp logs/*.log $SLURM_SUBMIT_DIR/logs/
+cp *.pt $SLURM_SUBMIT_DIR/saved_models/
+cp -r runs/* $SLURM_SUBMIT_DIR/runs/
+
+echo "Finito"
+

--- a/analysis/settings.py
+++ b/analysis/settings.py
@@ -31,6 +31,7 @@ class TrainingSettings(FileSettings):
     learning_rate: float = Field(default=5e-6)
     exponential_lr: bool = Field(default=False)
     gamma: float = Field(default=0.99, gt=0, lt=1)
+    save_name: str = Field(default=None)
 
 
 class InferenceSettings(FileSettings):

--- a/analysis/settings.py
+++ b/analysis/settings.py
@@ -28,6 +28,9 @@ class TrainingSettings(FileSettings):
     network_settings: dict = Field(default={})
     core_limit: int = Field(default=0, ge=0)
     batch_size: int = Field(default=16)
+    learning_rate: float = Field(default=5e-6)
+    exponential_lr: bool = Field(default=False)
+    gamma: float = Field(default=0.99, gt=0, lt=1)
 
 
 class InferenceSettings(FileSettings):

--- a/analysis/settings.py
+++ b/analysis/settings.py
@@ -27,6 +27,7 @@ class TrainingSettings(FileSettings):
     epochs: int = Field(default=10, gt=0)
     network_settings: dict = Field(default={})
     core_limit: int = Field(default=0, ge=0)
+    batch_size: int = Field(default=16)
 
 
 class InferenceSettings(FileSettings):

--- a/analysis/train_2layer_model.py
+++ b/analysis/train_2layer_model.py
@@ -19,7 +19,12 @@ from voyage_hdf5_dataset import VoyageHDF5Dataset
 def main(dataset: VoyageFilelistDataset, train_settings: TrainingSettings):
 
     start_time = dt.datetime.now().strftime("%Y%m%d_%H%M")
-    logfile = f"logs/train_model_{start_time}.log"
+    if train_settings.save_name is None:
+        train_settings.save_name = start_time
+    else:
+        train_settings.save_name += f"_{start_time}"
+
+    logfile = f"logs/train_model_{train_settings.save_name}.log"
     logger.info(f"Writing logs to {logfile}")
     logger.add(f"{logfile}")
 
@@ -66,8 +71,8 @@ def main(dataset: VoyageFilelistDataset, train_settings: TrainingSettings):
         train_data=train_data,
         test_data=test_data,
         epochs=train_settings.epochs,
-        save_file=f"trained_model_{start_time}.pt",
-        log_dir=f"runs/multilayer_{start_time}",
+        save_file=f"trained_model_{train_settings.save_name}.pt",
+        log_dir=f"runs/multilayer_{train_settings.save_name}",
         batch_size=train_settings.batch_size,
     )
 
@@ -84,8 +89,10 @@ if __name__ == "__main__":
     parser.add_argument(
         "-b", "--batch-size", help="Batch size", type=int
     )
-
-
+    parser.add_argument(
+        "-n", "--save-name", help="Model reference name, used in logs and save files",
+        type=str
+    )
 
     args = parser.parse_args()
 

--- a/analysis/train_2layer_model.py
+++ b/analysis/train_2layer_model.py
@@ -62,6 +62,7 @@ def main(dataset: VoyageFilelistDataset, train_settings: TrainingSettings):
         epochs=train_settings.epochs,
         save_file=f"trained_model_{start_time}.pt",
         log_dir=f"runs/multilayer_{start_time}",
+        batch_size=train_settings.batch_size,
     )
 
 

--- a/analysis/train_2layer_model.py
+++ b/analysis/train_2layer_model.py
@@ -7,6 +7,7 @@ import torch
 from astromorph.astromorph.src.byol import ByolTrainer, MinMaxNorm
 from loguru import logger
 from torch.utils.data import DataLoader
+from torch.optim.lr_scheduler import ExponentialLR
 from torchvision import transforms as T
 
 from models import CoastalVoyageModel
@@ -48,12 +49,17 @@ def main(dataset: VoyageFilelistDataset, train_settings: TrainingSettings):
 
     normalization_function = MinMaxNorm()
 
+    lr_scheduler = ExponentialLR if train_settings.exponential_lr is True else None
+
     model = CoastalVoyageModel(**train_settings.network_settings)
     trainer = ByolTrainer(
         network=model,
         augmentation_function=augmentation_function,
         normalization_function=normalization_function,
-        representation_size=train_settings.network_settings.get("dim_5", 128)
+        representation_size=train_settings.network_settings.get("dim_5", 128),
+        lr_scheduler=lr_scheduler,
+        lr_scheduler_options={"gamma": train_settings.gamma},
+        learning_rate=train_settings.learning_rate,
     )
 
     trainer.train_model(

--- a/analysis/train_2layer_model.py
+++ b/analysis/train_2layer_model.py
@@ -79,6 +79,9 @@ if __name__ == "__main__":
         "-c", "--configfile", help="Specify a configfile", required=True
     )
     parser.add_argument(
+        "-l", "--learning-rate", help="Learning rate", type=float
+    )
+    parser.add_argument(
         "-b", "--batch-size", help="Batch size", type=int
     )
 

--- a/analysis/train_2layer_model.py
+++ b/analysis/train_2layer_model.py
@@ -79,8 +79,19 @@ if __name__ == "__main__":
         "-c", "--configfile", help="Specify a configfile", required=True
     )
 
-    with open(parser.parse_args().configfile, "rb") as file:
+
+    args = parser.parse_args()
+
+    # Overriding settings are used to overwrite settings from the configfile
+    overriding_settings = vars(args)
+    configfile = overriding_settings.pop("configfile")
+    with open(configfile, "rb") as file:
         config_dict = tomllib.load(file)
+    # Overwrite the config file settings with command line settings
+    for key, value in overriding_settings.items():
+        if value is not None:
+            config_dict.update({key: value})
+
     settings = TrainingSettings(**config_dict)
 
     if settings.core_limit:

--- a/analysis/train_2layer_model.py
+++ b/analysis/train_2layer_model.py
@@ -78,6 +78,10 @@ if __name__ == "__main__":
     parser.add_argument(
         "-c", "--configfile", help="Specify a configfile", required=True
     )
+    parser.add_argument(
+        "-b", "--batch-size", help="Batch size", type=int
+    )
+
 
 
     args = parser.parse_args()


### PR DESCRIPTION
This PR adds functionality for doing a batchwise exploration of apramter space.
It includes jobscripts and command line overrides of config file settings.

- **Add batch size as a configurable parameter**
- **Add learning rate and learning rate scheduler to Settings**
- **Add learning rate settings to training script**
- **Add learning rate settings to example_config.toml**
- **Add functionality for overriding configs with CL args**
- **Override batch size through CL args**
- **Add functionality for CL override of learning rate**
- **Add functionality for a configurable savename**
- **Add jobscript for running on HPC cluster.**
- **Add batch script for exploration of parameter space.**
- **Add more verbose logging to the batch script**
